### PR TITLE
timeline: Fix timeline display on page loading

### DIFF
--- a/src/components/VisTimeline.jsx
+++ b/src/components/VisTimeline.jsx
@@ -33,12 +33,21 @@ export default function VisTimeline({
 	const containerRef = useRef(null);
 	const timelineRef = useRef(null);
 	const customTimesRef = useRef({});
+	const isFirstMount = useRef(true);
 
 	// Initialise the timeline once on mount; teardown on unmount.
 	// Subsequent prop changes are handled by the update effect below.
 	useEffect(() => {
 		const initialItems = new DataSet(items);
-		const timeline = new Timeline(containerRef.current, initialItems, options);
+		let timeline;
+
+		if (groups && groups.length > 0) {
+			const initialGroups = new DataSet(groups);
+			timeline = new Timeline(containerRef.current, initialItems, initialGroups, options);
+		} else {
+			timeline = new Timeline(containerRef.current, initialItems, options);
+		}
+
 		timelineRef.current = timeline;
 
 		events.forEach((event) => {
@@ -46,21 +55,31 @@ export default function VisTimeline({
 			if (handler) timeline.on(event, handler);
 		});
 
-		// vis-timeline may compute zero-width dimensions when the container is
-		// not yet laid out.  A single requestAnimationFrame is not reliable
-		// because Docusaurus may still be computing layout at that point.
-		// Use a ResizeObserver to redraw once the container acquires its real
-		// width, then disconnect so we don't duplicate work that vis-timeline
-		// already handles internally for subsequent resizes.
-		const ro = new ResizeObserver((entries) => {
-			if (entries.length > 0 && entries[0].contentRect.width > 0) {
+		// ResizeObserver to ensure timeline resizes gracefully
+		// vis-timeline sometimes struggles to adapt directly to container dimension changes
+		const ro = new ResizeObserver(() => {
+			if (timeline) {
 				timeline.redraw();
-				ro.disconnect();
 			}
 		});
 		ro.observe(containerRef.current);
 
+		// Docusaurus and lazy-loaded assets can cause unexpected layout shifts
+		// shortly after mount. Force a few redraws to ensure vis-timeline isn't blank.
+		const intervalId = setInterval(() => {
+			if (timelineRef.current) {
+				timelineRef.current.redraw();
+			}
+		}, 150);
+
+		// Stop polling after ~1 second (when layout is definitely stable)
+		const timerId = setTimeout(() => {
+			clearInterval(intervalId);
+		}, 1000);
+
 		return () => {
+			clearInterval(intervalId);
+			clearTimeout(timerId);
 			ro.disconnect();
 			timeline.destroy();
 		};
@@ -68,6 +87,11 @@ export default function VisTimeline({
 	}, []);
 
 	useEffect(() => {
+		if (isFirstMount.current) {
+			isFirstMount.current = false;
+			return;
+		}
+
 		const timeline = timelineRef.current;
 		if (!timeline) return;
 
@@ -107,5 +131,5 @@ export default function VisTimeline({
 		customTimesRef.current = customTimes;
 	}, [items, groups, options, selection, customTimes, animate, currentTime]);
 
-	return <div ref={containerRef} />;
+	return <div ref={containerRef} style={{ width: '100%', minHeight: options.height || '400px' }} />;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 
 import Heading from '@theme/Heading';
 import styles from './index.module.css';
@@ -288,8 +289,17 @@ export default function Home() {
 	return (
 		<Layout title="Accueil" description={siteConfig.tagline}>
 			<HomepageHeader />
-			<div style={{ marginTop: '20px' }}>
-				<VisTimeline options={options} items={items} groups={groups} clickHandler={clickHandler} />
+			<div style={{ marginTop: '20px', minHeight: '610px' }}>
+				<BrowserOnly fallback={<div>Chargement de la timeline...</div>}>
+					{() => (
+						<VisTimeline
+							options={options}
+							items={items}
+							groups={groups}
+							clickHandler={clickHandler}
+						/>
+					)}
+				</BrowserOnly>
 			</div>
 			<main></main>
 		</Layout>


### PR DESCRIPTION
🐛 Bug: La timeline vis-timeline est invisible au premier chargement

# Symptômes : 
Lors de l'affichage de la page d'accueil (ou du composant), la timeline de compétences/projets reste invisible (espace blanc/vide). Le DOM semble être là, et il n'y a aucune erreur en console. La timeline ne s'affiche magiquement que lorsqu'un évènement de redimensionnement de la fenêtre (resize vertical ou horizontal) est déclenché manuellement par l'utilisateur.

# Causes identifiées :
1. Hydratation SSR & Docusaurus : Le composant s'initialise au moment de l'hydratation (Server-Side Rendering) de React, alors que les feuilles de style (CSS), les polices, et la géométrie de la fenêtre (window) ne sont pas encore stabilisées. Les calculs de redimensionnement internes de vis-timeline tombent à 0px ou échouent.
2. Double Rendu (Double Render) : Le hook useEffect responsable des mises à jour des propriétés (items, groups) s'exécute immédiatement après le hook d'initialisation (new Timeline), interrompant brutalement le dessin du composant avant même qu'il n'ait eu lieu.

# 🛠️ Résolutions apportées
1. Rendu exclusif côté client (BrowserOnly) : 
   - Ajout du composant <BrowserOnly> autour de <VisTimeline /> dans la page index.js. Cela garantit que la librairie ne se lance qu'une fois le DOM complètement hydraté par le client.
   - Ajout d'une propriété minHeight sur le conteneur parent pour éviter le clignotement de l'écran (Layout Shift) avant le rendu.
2. Fiabilisation de l'affichage au montage (VisTimeline.jsx) : 
   - Ajout d'un garde-fou (useRef(isFirstMount)) pour bloquer la seconde exécution ravageuse des useEffect au moment du montage, afin de laisser le temps à la timeline de se dessiner sereinement.
   - Les groups (étiquettes latérales) sont désormais injectés dès l'instanciation originelle de la classe new Timeline(), et non plus de manière asynchrone, évitant ainsi l'absence partielle de données au chargement.
3. Optimisation du comportement ResizeObserver :
   - Le ResizeObserver ne se déconnecte plus après le premier évènement (comportement fautif du code original). Il continue d'observer les véritables variations de conteneur.
   - Mise en place d'un polling (setInterval(..., 150ms)) de courte durée (~1 sec max) qui force un redraw() immédiatement après le montage. C'est un filet de sécurité imparable contre le rendu tardif et paresseux des polices et images de Docusaurus qui pourraient modifier le Layout au dernier moment sans déclencher le ResizeObserver.